### PR TITLE
Replace deprecated plainToClass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /dist
 /packages/server/node_modules
 /node_modules
+
 # Logs
 logs
 *.log
@@ -37,3 +38,6 @@ lerna-debug.log*
 
 # Environment variables
 .env
+
+# Pre-commit hooks
+.husky

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -23,7 +23,7 @@
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
-    "prepare": "cd ../.. && husky install"
+    "prepare": "cd ../.. && husky install packages/server/.husky && husky install packages/client/.husky"
   },
   "dependencies": {
     "@emotion/css": "^11.10.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -22,7 +22,8 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "prepare": "cd ../.. && husky install"
   },
   "dependencies": {
     "@emotion/css": "^11.10.0",
@@ -41,6 +42,7 @@
     "aws-sdk": "^2.1258.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.13.2",
+    "husky": "^8.0.2",
     "node-ses": "^3.0.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/packages/server/src/email/email.controller.ts
+++ b/packages/server/src/email/email.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Post, HttpCode } from '@nestjs/common';
+import { Body, Controller, Post } from '@nestjs/common';
 import { EmailService } from './email.service';
 import * as AWS from 'aws-sdk';
 

--- a/packages/server/src/email/email.controller.ts
+++ b/packages/server/src/email/email.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import { Body, Controller, Post, HttpCode } from '@nestjs/common';
 import { EmailService } from './email.service';
 import * as AWS from 'aws-sdk';
 

--- a/packages/server/src/email/email.service.ts
+++ b/packages/server/src/email/email.service.ts
@@ -3,7 +3,7 @@ import { SqsMessageHandler, SqsConsumerEventHandler } from '@ssut/nestjs-sqs';
 import * as ses from 'node-ses';
 import * as AWS from 'aws-sdk';
 import { validate, ValidationError } from 'class-validator';
-import { plainToClass } from 'class-transformer';
+import { plainToInstance } from 'class-transformer';
 import { Email } from './validator/emailValidator.dto';
 
 @Injectable()
@@ -31,7 +31,7 @@ export class EmailService {
   @SqsMessageHandler(/** name: */ 'notification queue', /** batch: */ false)
   public async handleMessage(message: AWS.SQS.Message): Promise<void> {
     this.logger.log(`Message to be sent (type: ${typeof message}): ${message}, `);
-    const email = plainToClass(Email, message);
+    const email = plainToInstance(Email, message);
     const check = await this.isCompliantFormat(email);
 
     if (check.length === 0) {

--- a/packages/server/src/main.ts
+++ b/packages/server/src/main.ts
@@ -1,4 +1,4 @@
-import * as dotenv from 'dotenv'
+import * as dotenv from 'dotenv';
 import { NestFactory } from '@nestjs/core';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { AppModule } from './app.module';
@@ -6,9 +6,9 @@ import * as AWS from 'aws-sdk';
 import { ServiceConfigurationOptions } from 'aws-sdk/lib/service';
 
 async function bootstrap() {
-  dotenv.config()
+  dotenv.config();
 
-  let serviceConfigOptions : ServiceConfigurationOptions = {
+  let serviceConfigOptions: ServiceConfigurationOptions = {
     accessKeyId: process.env.AWS_ACCESS_KEY_ID,
     secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
     region: process.env.AWS_REGION,

--- a/packages/server/src/main.ts
+++ b/packages/server/src/main.ts
@@ -8,7 +8,7 @@ import { ServiceConfigurationOptions } from 'aws-sdk/lib/service';
 async function bootstrap() {
   dotenv.config();
 
-  let serviceConfigOptions: ServiceConfigurationOptions = {
+  const serviceConfigOptions: ServiceConfigurationOptions = {
     accessKeyId: process.env.AWS_ACCESS_KEY_ID,
     secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
     region: process.env.AWS_REGION,

--- a/packages/server/src/main.ts
+++ b/packages/server/src/main.ts
@@ -1,8 +1,22 @@
+import * as dotenv from 'dotenv'
 import { NestFactory } from '@nestjs/core';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { AppModule } from './app.module';
+import * as AWS from 'aws-sdk';
+import { ServiceConfigurationOptions } from 'aws-sdk/lib/service';
 
 async function bootstrap() {
+  dotenv.config()
+
+  let serviceConfigOptions : ServiceConfigurationOptions = {
+    accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+    region: process.env.AWS_REGION,
+    endpoint: process.env.LOCAL_QUEUE_URL
+  };
+
+  AWS.config.update(serviceConfigOptions);
+
   const app = await NestFactory.create(AppModule);
   const config = new DocumentBuilder()
     .setTitle('Notification Service')


### PR DESCRIPTION
# Description

Replace deprecated `plainToClass` with `plainToInstance`

## Checklist

- [x] This PR can be reviewed in under 30 minutes
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have assigned reviewers to this PR.
